### PR TITLE
fix: replace deprecated query.get usage

### DIFF
--- a/FULL APP Main/backend/app/crud/product.py
+++ b/FULL APP Main/backend/app/crud/product.py
@@ -48,7 +48,7 @@ def _calculate_product_costs_and_prices(db: Session, db_product: Producto) -> No
     total_cogs = 0.0
     db.refresh(db_product, attribute_names=['insumos_asociados'])
     for producto_insumo in db_product.insumos_asociados:
-        insumo = db.query(Insumo).get(producto_insumo.insumo_id)
+        insumo = db.get(Insumo, producto_insumo.insumo_id)
         if insumo:
             total_cogs += producto_insumo.cantidad_necesaria * insumo.costo_unitario_compra
     db_product.cogs = total_cogs

--- a/FULL APP Main/debugging/tests/test_product_calculations.py
+++ b/FULL APP Main/debugging/tests/test_product_calculations.py
@@ -84,7 +84,7 @@ def test_product_calculations():
         
         print("\n=== DETALLES DE INSUMOS ===")
         for producto_insumo in created_product.insumos_asociados:
-            insumo = db.query(Insumo).get(producto_insumo.insumo_id)
+            insumo = db.get(Insumo, producto_insumo.insumo_id)
             costo_insumo = producto_insumo.cantidad_necesaria * insumo.costo_unitario_compra
             print(f"- {insumo.nombre}: {producto_insumo.cantidad_necesaria} {insumo.unidad_medida_compra} x ${insumo.costo_unitario_compra} = ${costo_insumo}")
         


### PR DESCRIPTION
## Summary
- use SQLAlchemy `Session.get` when loading insumos during product cost calculation
- update product calculation debugging test to match new API

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx', No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_688ee71b0c24832dbdabef20658a1522