### PR TITLE
fix: usar sesión como unidad de venta

### DIFF
--- a/FULL APP Main/src/screens/CreateProductScreen.js
+++ b/FULL APP Main/src/screens/CreateProductScreen.js
@@ -81,7 +81,7 @@ const CreateProductScreen = () => {
 
   // Unidades de venta
   const units = [
-    'unidad', 'kg', 'litro', 'metro', 'hora', 'sesion'
+    'unidad', 'kg', 'litro', 'metro', 'hora', 'sesión'
   ];
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- corrige la unidad `sesion` por `sesión` en CreateProductScreen

## Testing
- `npx prettier --check "FULL APP Main/src/screens/CreateProductScreen.js"`
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688eee6ed78c832dabb08e8e011d92c9