### PR TITLE
test: cover MessageBox empty message handling and type classes

### DIFF
--- a/FULL APP Main/frontend/src/__tests__/MessageBox.test.js
+++ b/FULL APP Main/frontend/src/__tests__/MessageBox.test.js
@@ -3,14 +3,22 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import MessageBox from '../components/MessageBox';
 
 describe('MessageBox', () => {
-  it('muestra el mensaje y tipo', () => {
+  it('muestra el mensaje y aplica la clase según el tipo', () => {
     render(<MessageBox message="¡Éxito!" type="success" onClose={() => {}} />);
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveClass('bg-green-600');
     expect(screen.getByText('¡Éxito!')).toBeInTheDocument();
   });
+
   it('llama a onClose al hacer click en cerrar', () => {
     const onClose = jest.fn();
     render(<MessageBox message="Error" type="error" onClose={onClose} />);
     fireEvent.click(screen.getByRole('button'));
     expect(onClose).toHaveBeenCalled();
   });
-}); 
+
+  it('no renderiza nada cuando message es vacío', () => {
+    const { container } = render(<MessageBox message="" />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- extend MessageBox tests to assert success type applies `bg-green-600` class
- ensure MessageBox renders nothing when message is empty

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ef0a16df4832d8d717d051b43e565